### PR TITLE
Remove unnecessary 'if startsWith' trigger

### DIFF
--- a/.github/workflows/mortality_data_extraction.yml
+++ b/.github/workflows/mortality_data_extraction.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
     build:
-        if: startsWith(github.head_ref, 'mortalidade')
         runs-on: ubuntu-latest
         container: python:3
 


### PR DESCRIPTION
- The github action 'moratlidade_data_extraction.yml' had a condition that will only run the command if the pull request had a branch name starting with "mortalidade". This is unnecessary.