### PR TITLE
fix incorrect column order

### DIFF
--- a/scripts/scraping.py
+++ b/scripts/scraping.py
@@ -198,7 +198,7 @@ class MortalityScrapping:
                         df.rename(str.lower, axis="columns", inplace=True)
                         df = df.pivot(columns=t.lower(), values="óbitos")
                 df.columns = [self.__rename_columns(x, t) for x in df.columns]
-                df.columns = df.columns.sort_values()
+                df = df[sorted(df.columns)]
 
             tables.append(df)
 


### PR DESCRIPTION
Fixes issue #37 - a bug caused an incorrect sorting of columns in the tables for grupos etários, distritos, causas de morte e ACES and a mix up of various columns